### PR TITLE
feat: add second public subnet and EKS module configuration

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -42,3 +42,18 @@ output "ssh_command" {
   description = "SSH command to connect to the EC2 instance"
   value       = "ssh -i notifyops-key.pem ec2-user@${aws_instance.notifyops_instance.public_ip}"
 } 
+
+output "eks_cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "eks_cluster_oidc_issuer_url" {
+  description = "EKS cluster OIDC issuer URL"
+  value       = module.eks.oidc_provider
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,8 +16,26 @@ variable "public_subnet_cidr" {
   default     = "10.0.1.0/24"
 }
 
+variable "public_subnet_2_cidr" {
+  description = "CIDR block for second public subnet"
+  type        = string
+  default     = "10.0.2.0/24"
+}
+
 variable "ssh_public_key" {
   description = "SSH public key for EC2 instance access"
   type        = string
   default     = ""
 } 
+
+variable "eks_cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "NotifyOps"
+}
+
+variable "eks_version" {
+  description = "EKS Kubernetes version"
+  type        = string
+  default     = "1.29"
+}


### PR DESCRIPTION
This pull request introduces the setup for a minimal AWS EKS (Elastic Kubernetes Service) cluster within the existing Terraform configuration. The main changes include provisioning a second public subnet, updating route table associations, adding EKS cluster resources, and exposing relevant outputs and variables for configuration.

**EKS Cluster Setup:**

* Added a new `module "eks"` block in `main.tf` to provision a minimal EKS cluster using the `terraform-aws-modules/eks/aws` module, including a managed node group and public endpoint access. The EKS cluster uses both public subnets for high availability.

**Networking Enhancements:**

* Created a new public subnet resource `aws_subnet.public_subnet_2` and associated it with the VPC, using a separate CIDR block and availability zone for redundancy.
* Added a new route table association `aws_route_table_association.public_rta_2` to connect the new subnet to the public route table, ensuring internet access for resources in this subnet.

**Configuration and Outputs:**

* Introduced new variables in `variables.tf` for the second public subnet's CIDR, EKS cluster name, and EKS version, allowing for flexible configuration.
* Added outputs in `outputs.tf` to expose the EKS cluster name, endpoint, and OIDC issuer URL for use in other modules or for user reference.
