### PR TITLE
feat: update deployment and service configurations

### DIFF
--- a/k8s/apps/web/deployment.yaml
+++ b/k8s/apps/web/deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     component: frontend
     version: v1
 spec:
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   replicas: 2
   selector:
     matchLabels:
@@ -24,6 +30,18 @@ spec:
         prometheus.io/port: "3000"
         prometheus.io/path: "/api/metrics"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - web
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: notifyops-sa
       containers:
       - name: web

--- a/k8s/apps/web/service.yaml
+++ b/k8s/apps/web/service.yaml
@@ -6,12 +6,14 @@ metadata:
   labels:
     app: web
     component: frontend
+    version: v1
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "3000"
     prometheus.io/path: "/api/metrics"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - name: http
       port: 3000
@@ -32,8 +34,10 @@ metadata:
   labels:
     app: web
     component: static
+    version: v1
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - name: http
       port: 3000


### PR DESCRIPTION
This pull request introduces several improvements to the Kubernetes deployment and service configurations for the `web` application. The main focus is on enhancing deployment reliability, scheduling, and internal traffic routing. Below are the most important changes grouped by theme:

**Deployment strategy and reliability:**

* Added a `revisionHistoryLimit` of 3 to keep a history of previous ReplicaSets for easier rollbacks.
* Configured a `RollingUpdate` deployment strategy with `maxUnavailable: 0` and `maxSurge: 1` to ensure zero downtime during updates.

**Pod scheduling improvements:**

* Introduced `podAntiAffinity` rules to prefer spreading `web` pods across different nodes, improving availability in case of node failures.

**Service configuration enhancements:**

* Added `version: v1` label to both frontend and static `web` services for better version tracking and selection. 
* Set `internalTrafficPolicy: Cluster` on both services to ensure traffic is routed cluster-wide rather than node-local, which can improve load balancing. 